### PR TITLE
Fix some bugs found during usage

### DIFF
--- a/spec/Docbot/Reviewer/LineLengthSpec.php
+++ b/spec/Docbot/Reviewer/LineLengthSpec.php
@@ -63,4 +63,19 @@ class LineLengthSpec extends ReviewerBehaviour
             '        // a line that is around 80 characters long, so there should not be an error here',
         )));
     }
+
+    function it_ignores_too_long_schemaLocation_lines(ExecutionContextInterface $context)
+    {
+        PredictThatReviewer::shouldNotReportAnyError($context);
+
+        $this->review(Text::fromArray(array(
+            '.. code-block:: xml',
+            '',
+            '    <?xml version="1.0" encoding="UTF-8"?>',
+            '    <srv:container xmlns="http://symfony.com/schema/dic/security"',
+            '        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
+            '        xmlns:srv="http://symfony.com/schema/dic/services"',
+            '        xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">',
+        )));
+    }
 }

--- a/spec/Docbot/Reviewer/LineLengthSpec.php
+++ b/spec/Docbot/Reviewer/LineLengthSpec.php
@@ -43,4 +43,13 @@ class LineLengthSpec extends ReviewerBehaviour
             '    // but this should error, as it is longer than 80 characters long. Oh dear, what did I do?',
         )));
     }
+
+    function it_allows_definitions_to_exceed_72_characters(ExecutionContextInterface $context)
+    {
+        PredictThatReviewer::shouldNotReportAnyError($context);
+
+        $this->review(Text::fromArray(array(
+            '**type**: ``string`` **default**: ``This is a long constraint error message, but it should be allowed.``',
+        )));
+    }
 }

--- a/spec/Docbot/Reviewer/LineLengthSpec.php
+++ b/spec/Docbot/Reviewer/LineLengthSpec.php
@@ -52,4 +52,15 @@ class LineLengthSpec extends ReviewerBehaviour
             '**type**: ``string`` **default**: ``This is a long constraint error message, but it should be allowed.``',
         )));
     }
+
+    function it_removes_indentation_of_code_blocks(ExecutionContextInterface $context)
+    {
+        PredictThatReviewer::shouldNotReportAnyError($context);
+
+        $this->review(Text::fromArray(array(
+            '    .. code-block:: php',
+            '',
+            '        // a line that is around 80 characters long, so there should not be an error here',
+        )));
+    }
 }

--- a/spec/Docbot/Reviewer/RefRoleSpacingSpec.php
+++ b/spec/Docbot/Reviewer/RefRoleSpacingSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\Docbot\Reviewer;
+
+use Gnugat\Redaktilo\Text;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+use spec\helpers\Prediction\Reviewer as PredictThatReviewer;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
+
+/**
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class RefRoleSpacingSpec extends ReviewerBehaviour
+{
+    function it_errors_when_there_is_no_space_between_label_and_reference(ExecutionContextInterface $context, ConstraintViolationBuilderInterface $builder)
+    {
+        foreach (array('ref', 'doc') as $role) {
+            $this->testWithRole($role, $context, $builder);
+        }
+    }
+
+    private function testWithRole($role, $context, $builder)
+    {
+        PredictThatReviewer::shouldReportError(
+            $context, $builder,
+            'There should be a space between "%label%" and "%ref%".', 1,
+            array(
+                '%label%' => 'a label',
+                '%ref%' => '<the_reference>',
+            )
+        );
+
+        $this->review(Text::fromArray(array(
+            ':'.$role.':`a label<the_reference>`',
+        )));
+    }
+}

--- a/spec/Docbot/Reviewer/TitleLevelSpec.php
+++ b/spec/Docbot/Reviewer/TitleLevelSpec.php
@@ -2,6 +2,7 @@
 
 namespace spec\Docbot\Reviewer;
 
+use Gnugat\Redaktilo\File;
 use Gnugat\Redaktilo\Text;
 use spec\helpers\Prediction\Reviewer as PredictThatReviewer;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
@@ -59,5 +60,18 @@ class TitleLevelSpec extends ReviewerBehaviour
             'Title level 2',
             '-------------',
         )));
+    }
+
+    function it_allows_inc_files_to_start_with_a_deeper_level(ExecutionContextInterface $context)
+    {
+        PredictThatReviewer::shouldNotReportAnyError($context);
+
+        $file = File::fromArray(array(
+            'Title level 3',
+            '~~~~~~~~~~~~~',
+        ));
+        $file->setFilename('included_file.rst.inc');
+        
+        $this->review($file);
     }
 }

--- a/src/Reporter/Console.php
+++ b/src/Reporter/Console.php
@@ -42,7 +42,19 @@ class Console implements Reporter
         }
 
         $currentLineNumber = 0;
-        /** @var ConstraintViolation $violation */
+        $constraintViolationList = iterator_to_array($constraintViolationList);
+        $that = $this;
+        usort($constraintViolationList, function (ConstraintViolation $a, ConstraintViolation $b) use ($that) {
+            $aNumber = $that->getLineNumber($a);
+            $bNumber = $that->getLineNumber($b);
+
+            if ($aNumber === $bNumber) {
+                return 0;
+            }
+
+            return $aNumber > $bNumber ? 1 : -1;
+        });
+
         foreach ($constraintViolationList as $violation) {
             $lineNumber = $this->getLineNumber($violation);
             if ($lineNumber !== $currentLineNumber) {
@@ -70,7 +82,8 @@ class Console implements Reporter
         $this->output->writeln($this->formatterHelper->formatBlock($message, 'bg='.$color, true));
     }
 
-    private function getLineNumber(ConstraintViolation $violation)
+    /** @internal */
+    public function getLineNumber(ConstraintViolation $violation)
     {
         if (!preg_match('/lines\[(\d+)\]/', $violation->getPropertyPath(), $matches)) {
             throw new \InvalidArgumentException(sprintf(

--- a/src/Reviewer/LineLength.php
+++ b/src/Reviewer/LineLength.php
@@ -29,7 +29,7 @@ class LineLength extends Base
             }
 
             if (preg_match('/^\s{'.$this->inCodeBlock.'}/', $line)) {
-                if (strlen(trim($line)) > 85) {
+                if (strlen(trim($line)) > 85 && !preg_match('/^\w+:schemaLocation/', ltrim($line))) {
                     $this->addError('In order to avoid horizontal scrollbars, you should wrap the code on a 85 character limit');
                 }
 

--- a/src/Reviewer/LineLength.php
+++ b/src/Reviewer/LineLength.php
@@ -43,6 +43,11 @@ class LineLength extends Base
             return;
         }
 
+        // exception: type definitions may exceed 72 character limit
+        if (substr($line, 0, 8) === '**type**') {
+            return;
+        }
+
         if (false !== strpos(substr(rtrim($line), 71), ' ')) {
             $this->addError('A line should be wrapped after the first word that crosses the 72th character');
         }

--- a/src/Reviewer/RefRoleSpacing.php
+++ b/src/Reviewer/RefRoleSpacing.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Docbot\Reviewer;
+
+use Gnugat\Redaktilo\Text;
+
+class RefRoleSpacing extends Base
+{
+    public function reviewLine($line, $lineNumber, Text $file)
+    {
+        preg_match_all('/:ref:`(?P<label>[^<]+)(?P<ref><[^>]+>)`/', $line, $matches, PREG_SET_ORDER);
+
+        foreach ($matches as $reference) {
+            if (substr($reference['label'], -1) !== ' ') {
+                $this->addError('There should be a space between "%label%" and "%ref%".', array(
+                    '%label%' => $reference['label'],
+                    '%ref%' => $reference['ref'],
+                ));
+            }
+        }
+    }
+}

--- a/src/Reviewer/TitleLevel.php
+++ b/src/Reviewer/TitleLevel.php
@@ -2,6 +2,7 @@
 
 namespace Docbot\Reviewer;
 
+use Gnugat\Redaktilo\File;
 use Gnugat\Redaktilo\Text;
 
 /**
@@ -19,6 +20,14 @@ class TitleLevel extends Base
         5 => '"',
     );
     private $currentLevel = 1;
+    private $startLevelIsDetermined = false;
+
+    public function review(Text $file)
+    {
+        $this->startLevelIsDetermined = false;
+
+        parent::review($file);
+    }
 
     public function reviewLine($line, $lineNumber, Text $file)
     {
@@ -31,6 +40,13 @@ class TitleLevel extends Base
                 $this->addError('Only =, -, ~, . and " should be used as title underlines');
 
                 return;
+            }
+
+            // .inc files are allowed to start with a deeper level.
+            $isIncludedFile = $file instanceof File && preg_match('/\.inc/', $file->getFilename());
+            if ($isIncludedFile && !$this->startLevelIsDetermined) {
+                $this->startLevelIsDetermined = true;
+                $this->currentLevel = $level;
             }
 
             if ($level <= $this->currentLevel) {


### PR DESCRIPTION
The line length reviewer is a very hard one, due to all exceptions of the rule (code blocks, some code lines (e.g. the `schemaLocation` attribute), type definitions (`**type**: ...`), etc). This PR adds just some more exceptions to the line length reviewer.

Besides that, it fixes included file reviews and it adds a new reviewer for `:ref:`label<ref>``.
